### PR TITLE
chore(export-order) : check if has updated by tiny before send

### DIFF
--- a/functions/lib/integration/export-order.js
+++ b/functions/lib/integration/export-order.js
@@ -2,7 +2,6 @@ const errorHandling = require('../store-api/error-handling')
 const Tiny = require('../tiny/constructor')
 const parseOrder = require('./parsers/order-to-tiny/')
 const parseStatus = require('./parsers/order-to-tiny/status')
-const formatDate = require('../../helpers/format-tiny-date')
 const selectTypeUpdate = require('../../helpers/select-type-update')
 const handleJob = require('./handle-job')
 

--- a/functions/lib/integration/export-order.js
+++ b/functions/lib/integration/export-order.js
@@ -18,11 +18,12 @@ module.exports = ({ appSdk, storeId, auth }, tinyToken, queueEntry, appData, can
       console.log(`#${storeId} ${orderId} searching order ${order.number}`)
       const checkFulfillmentFromTiny = order => {
         const fulfillmentStatus = order.fulfillment_status && order.fulfillment_status.current
-        if (fulfillmentStatus && order.fulfillments.length) {
-          return order.fulfillments.some(fulfillment => {
+        if (fulfillmentStatus && order.fulfillments && order.fulfillments.length) {
+          const fulfillment = order.fulfillments.find(fulfillment => fulfillment.status === fulfillmentStatus)
+          if (fulfillment) {
             const flags = fulfillment && fulfillment.flags
             return flags.includes('from-tiny')
-          })
+          }
         }
         return false
       }

--- a/functions/lib/integration/export-order.js
+++ b/functions/lib/integration/export-order.js
@@ -2,6 +2,8 @@ const errorHandling = require('../store-api/error-handling')
 const Tiny = require('../tiny/constructor')
 const parseOrder = require('./parsers/order-to-tiny/')
 const parseStatus = require('./parsers/order-to-tiny/status')
+const formatDate = require('../../helpers/format-tiny-date')
+const selectTypeUpdate = require('../../helpers/select-type-update')
 const handleJob = require('./handle-job')
 
 module.exports = ({ appSdk, storeId, auth }, tinyToken, queueEntry, appData, canCreateNew) => {
@@ -16,18 +18,39 @@ module.exports = ({ appSdk, storeId, auth }, tinyToken, queueEntry, appData, can
       }
       const tiny = new Tiny(tinyToken)
       console.log(`#${storeId} ${orderId} searching order ${order.number}`)
-      const checkFulfillmentFromTiny = order => {
-        const fulfillmentStatus = order.fulfillment_status && order.fulfillment_status.current
-        if (fulfillmentStatus && Array.isArray(order.fulfillments)) {
-          return Boolean(order.fulfillments.find(({ status, flags }) => {
-            return status === fulfillmentStatus && flags && flags.includes('from-tiny')
-          }))
+      const findLatestUpdate = order => {
+        const fulfillments = order.fulfillments
+        const paymentsHistory = order.payments_history
+        let latestFulfillment, latestPayment
+        if (Array.isArray(fulfillments)) {
+          latestFulfillment = fulfillments.reduce((a, b) => (a.date_time > b.date_time ? a : b))
         }
-        return false
+        if (Array.isArray(paymentsHistory)) {
+          latestPayment = paymentsHistory.reduce((a, b) => (a.date_time > b.date_time ? a : b))
+        }
+        if (latestFulfillment && latestPayment) {
+          return latestFulfillment.date_time > latestPayment.date_time ? latestFulfillment : latestPayment
+        } else if (latestFulfillment && !latestPayment) {
+          return latestFulfillment
+        } else if (!latestFulfillment && latestPayment) {
+          return latestPayment
+        }
       }
-      if (checkFulfillmentFromTiny(order)) {
-        console.log(`#${storeId} ${orderId} skipped to not send status came by tiny`)
-        return null
+      const latestUpdateStatus = findLatestUpdate(order)
+      if (selectTypeUpdate(latestStatusUpdate) === 'fulfillment') {
+        const checkFulfillmentFromTiny = order => {
+          const fulfillmentStatus = order.fulfillment_status && order.fulfillment_status.current
+          if (fulfillmentStatus && Array.isArray(order.fulfillments)) {
+            return Boolean(order.fulfillments.find(({ status, flags }) => {
+              return status === fulfillmentStatus && flags && flags.includes('from-tiny')
+            }))
+          }
+          return false
+        }
+        if (checkFulfillmentFromTiny(order)) {
+          console.log(`#${storeId} ${orderId} skipped to not send status came by tiny`)
+          return null
+        }
       }
 
       const job = tiny.post('/pedidos.pesquisa.php', { numeroEcommerce: String(order.number) })

--- a/functions/lib/integration/export-order.js
+++ b/functions/lib/integration/export-order.js
@@ -19,11 +19,9 @@ module.exports = ({ appSdk, storeId, auth }, tinyToken, queueEntry, appData, can
       const checkFulfillmentFromTiny = order => {
         const fulfillmentStatus = order.fulfillment_status && order.fulfillment_status.current
         if (fulfillmentStatus && Array.isArray(order.fulfillments)) {
-          const fulfillment = order.fulfillments.find(fulfillment => fulfillment.status === fulfillmentStatus)
-          if (fulfillment) {
-            const flags = fulfillment && fulfillment.flags
-            return flags.includes('from-tiny')
-          }
+          return Boolean(order.fulfillments.find(({ status, flags }) => {
+            return status === fulfillmentStatus && flags && flags.includes('from-tiny')
+          }))
         }
         return false
       }

--- a/functions/lib/integration/export-order.js
+++ b/functions/lib/integration/export-order.js
@@ -27,8 +27,7 @@ module.exports = ({ appSdk, storeId, auth }, tinyToken, queueEntry, appData, can
         }
         return false
       }
-      const hasUpdatedByTiny = checkFulfillmentFromTiny(order)
-      if (hasUpdatedByTiny) {
+      if (checkFulfillmentFromTiny(order)) {
         console.log(`#${storeId} ${orderId} skipped to not send status came by tiny`)
         return null
       }

--- a/functions/lib/integration/export-order.js
+++ b/functions/lib/integration/export-order.js
@@ -18,7 +18,7 @@ module.exports = ({ appSdk, storeId, auth }, tinyToken, queueEntry, appData, can
       console.log(`#${storeId} ${orderId} searching order ${order.number}`)
       const checkFulfillmentFromTiny = order => {
         const fulfillmentStatus = order.fulfillment_status && order.fulfillment_status.current
-        if (fulfillmentStatus && order.fulfillments && order.fulfillments.length) {
+        if (fulfillmentStatus && Array.isArray(order.fulfillments)) {
           const fulfillment = order.fulfillments.find(fulfillment => fulfillment.status === fulfillmentStatus)
           if (fulfillment) {
             const flags = fulfillment && fulfillment.flags

--- a/functions/lib/integration/helpers/select-type-update.js
+++ b/functions/lib/integration/helpers/select-type-update.js
@@ -1,0 +1,28 @@
+module.exports = latestUpdate => {
+    if (latestUpdate.status) {
+        switch (latestUpdate.status) {
+            case 'pending':
+            case 'under_analysis':
+            case 'unknown':
+            case 'authorized':
+            case 'partially_paid':
+            case 'voided':
+            case 'refunded':
+            case 'in_dispute':
+            case 'unauthorized':
+            case 'paid':
+                return 'financial'
+            case 'in_production':
+            case 'in_separation':
+            case 'invoice_issued':
+            case 'ready_for_shipping':
+            case 'shipped':
+            case 'partially_shipped':
+            case 'delivered':
+            case 'returned':
+                return 'fulfillment'
+        }
+    }
+    return 'financial'
+}
+  


### PR DESCRIPTION
Today we have a loop problem when status isnt correctly. 
Some times we receive two status closely

![image](https://user-images.githubusercontent.com/35343551/187913452-c325fe2a-6217-40db-89b0-c33a4d153d81.png)

So, we receive webhook status and patch him on tiny. But when we patch, sometimes tiny already has new status, so we change tiny to preparado para envio, when tiny was enviado, so notify us ... and order in tiny goes to wrong side of fulfillment people and then they need to re-work all orders to separe then to shipped again.




